### PR TITLE
chore: switch dependabot to security-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,87 +1,26 @@
 version: 2
 
+# Security-only: open-pull-requests-limit 0 disables scheduled version bumps,
+# while Dependabot security-advisory updates remain enabled.
 updates:
-  # Enable version updates for npm
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
-      time: "09:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     assignees:
       - "ny085"
-    commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
-      include: "scope"
     labels:
       - "dependencies"
-      - "automated"
-    
-    # Group updates by dependency type
-    groups:
-      # Production dependencies
-      production-dependencies:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "@types/*"
-          - "typescript"
-          - "jest"
-          - "eslint*"
-          - "@typescript-eslint/*"
-          - "rollup*"
-          - "@rollup/*"
-          - "rimraf"
-          - "ts-jest"
-          - "tslib"
-          - "typedoc"
-        update-types:
-          - "minor"
-          - "patch"
-      
-      # Development dependencies
-      development-dependencies:
-        patterns:
-          - "@types/*"
-          - "typescript"
-          - "jest"
-          - "eslint*"
-          - "@typescript-eslint/*"
-          - "rollup*"
-          - "@rollup/*"
-          - "rimraf"
-          - "ts-jest"
-          - "tslib"
-          - "typedoc"
-        update-types:
-          - "minor"
-          - "patch"
+      - "security"
 
-    # Ignore specific dependencies that require manual updates
-    ignore:
-      # Ignore major version updates for critical dependencies
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "jest"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "rollup"
-        update-types: ["version-update:semver-major"]
-
-  # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
-      time: "10:00"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     assignees:
       - "ny085"
-    commit-message:
-      prefix: "ci"
-      include: "scope"
     labels:
       - "github-actions"
-      - "automated"
+      - "security"


### PR DESCRIPTION
## Why

Merging the dependabot config in #16 activated Dependabot, which immediately opened **13 PRs** — one per outdated dependency (mostly major dev-dep bumps), several with failing CI. The current config does scheduled weekly version bumps with a high PR limit, so this will recur.

## What

- Set `open-pull-requests-limit: 0` for both ecosystems (npm + github-actions), which **disables scheduled version-bump PRs** while leaving **Dependabot security-advisory updates enabled**.
- Drops the grouping/ignore config that no longer applies.

## Follow-up (already done outside this PR)
- Closed the 3 failing Dependabot PRs (#22, #23, #25 — eslint/typescript-eslint majors that break the current build).
- The remaining green Dependabot PRs (#17–#21, #24, #26–#29) are left for you to triage or close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)